### PR TITLE
Fix sourcelist plugin syntax error

### DIFF
--- a/plugins/sourcelist.pl
+++ b/plugins/sourcelist.pl
@@ -37,10 +37,10 @@ sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
 	::rptMsg("Launching sourcelist v.".$VERSION);
-	::rptMsg("sourcelist v.".$VERSION); 
-	::rptMsg("(".$config{hive}.") ".getShortDescr())
+	::rptMsg("sourcelist v.".$VERSION);
+	::rptMsg("(".$config{hive}.") ".getShortDescr());
 	::rptMsg("MITRE: ".$config{MITRE}." (".$config{category}.")");
-	::rptMsg("");;  
+	::rptMsg("");
 
 	my $key_path = ('Software\\Microsoft\\Installer\\Products');
 	


### PR DESCRIPTION
### Summary
This pull request fixes a syntax error in the sourcelist plugin of RegRipper4.0.

### Changes Made
- Added missing ";" at the end of line 41
- Removed duplicate ";" at the end of line 43
- Removed some trailing blank spaces

### Related Issues
- Fixes issue #7 (Syntax error in sourcelist plugin)

### How to Test
1. Pull the branch "bugfix/fix-sourcelist-plugin-syntax-error".
2. Run command line tool "rip.exe" with all hive-specific plugins for an input user hive file (e.g., rip.exe -a -r "ntuser.dat" > test.txt).
3. Notice that the sourcelist plugin executes without error.

Thanks and all the best :)