### PR TITLE
Clean plugin launch messages

### DIFF
--- a/plugins/link_click.pl
+++ b/plugins/link_click.pl
@@ -41,7 +41,7 @@ my $office_version;
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  link_click v.".$VERSION);
+	::logMsg("Launching link_click v.".$VERSION);
 	::rptMsg("link_click v.".$VERSION);
 	::rptMsg("MITRE: ".$config{MITRE}." (".$config{category}.")");
 	::rptMsg("");

--- a/plugins/msoffice.pl
+++ b/plugins/msoffice.pl
@@ -57,7 +57,7 @@ my %vba = (1 => "Enable all macros",
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  msoffice v.".$VERSION);
+	::logMsg("Launching msoffice v.".$VERSION);
 	my $reg = Parse::Win32Registry->new($ntuser);
 	my $root_key = $reg->get_root_key;
 	

--- a/plugins/msoffice_tln.pl
+++ b/plugins/msoffice_tln.pl
@@ -53,7 +53,7 @@ my %vba = (1 => "Enable all macros",
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-#	::logMsg("Launching  msoffice_tln v.".$VERSION);
+#	::logMsg("Launching msoffice_tln v.".$VERSION);
 	my $reg = Parse::Win32Registry->new($ntuser);
 	my $root_key = $reg->get_root_key;
 	

--- a/plugins/onenote.pl
+++ b/plugins/onenote.pl
@@ -39,7 +39,7 @@ my $office_version;
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  onenote v.".$VERSION);
+	::logMsg("Launching onenote v.".$VERSION);
 	my $reg = Parse::Win32Registry->new($ntuser);
 	my $root_key = $reg->get_root_key;
 	

--- a/plugins/outlookhomepage.pl
+++ b/plugins/outlookhomepage.pl
@@ -41,7 +41,7 @@ my $office_version;
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  outlookhomepage v.".$VERSION);
+	::logMsg("Launching outlookhomepage v.".$VERSION);
 	::rptMsg("outlookhomepage v.".$VERSION);
 	::rptMsg("MITRE: ".$config{MITRE}." (".$config{category}.")");
 	::rptMsg("");

--- a/plugins/protectedview.pl
+++ b/plugins/protectedview.pl
@@ -39,7 +39,7 @@ my $office_version;
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  protectedview v.".$VERSION);
+	::logMsg("Launching protectedview v.".$VERSION);
 	::rptMsg("protectedview v.".$VERSION);
 	::rptMsg("MITRE: ".$config{MITRE}." (".$config{category}.")");
 	::rptMsg("");

--- a/plugins/resiliency.pl
+++ b/plugins/resiliency.pl
@@ -46,7 +46,7 @@ my @apps = ("Word","Excel","OneNote","OutLook");
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  resiliency v.".$VERSION);
+	::logMsg("Launching resiliency v.".$VERSION);
 	::rptMsg("resiliency v.".$VERSION);
 	::rptMsg("MITRE: ".$config{MITRE}." (".$config{category}.")");
 	::rptMsg("");

--- a/plugins/wordstartup.pl
+++ b/plugins/wordstartup.pl
@@ -40,7 +40,7 @@ my $office_version;
 sub pluginmain {
 	my $class = shift;
 	my $ntuser = shift;
-	::logMsg("Launching  wordstartup v.".$VERSION);
+	::logMsg("Launching wordstartup v.".$VERSION);
 	::rptMsg("wordstartup v.".$VERSION);
 	::rptMsg("MITRE: ".$config{MITRE}." (".$config{category}.")");
 	::rptMsg("");


### PR DESCRIPTION
### Summary
This pull request adjusts the launch message of 8 plugins to match all other plugins of RegRipper4.0.

### Changes Made
Removed duplicate blank spaces in launch message of the following plugins:
- link_click
- msoffice
- msoffice_tln
- onenote
- outlookhomepage
- protectedview
- resiliency
- wordstartup

### Additional Information
- The launch messages are located inside the "pluginmain" subroutine and they are part of "logMsg" logging.

### Related Issues
- No issue created, since this is a purely cosmetic adjustment.

### How to Test
1. Pull the branch "refactor/clean-plugin-launch-messages".
2. Run command line tool "rip.exe" with all hive-specific plugins for an input user hive file (e.g., rip.exe -a -r "ntuser.dat" > test.txt).
3. Notice that all plugin launch messages are now formatted the same way.

Thank you and have a nice day :)