### PR TITLE
Add Harlan's recent blog post about transaction logs to its section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ This tool does NOT automatically process hive transaction logs. If you need
 to incorporate data from hive transaction logs into your analysis, consider merging
 the data via Maxim Suhanov's `yarp` + `registryFlush.py`, or via Eric Zimmerman's `rla.exe`
 which is included in [Eric's Registry Explorer/RECmd](https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip).
+
+If you consider incorporating transaction logs, read the 
+article [RegRipper - Handling transaction logs](https://windowsir.blogspot.com/2025/07/regripper.html) about 
+the reasons why RegRipper omits doing it automatically.


### PR DESCRIPTION
Proposal to add Harlan's recent article about transaction logs into the readme where the topic is mentioned. The blog post is well-written and everyone should read that before instead of blindly merging the transaction logs.